### PR TITLE
Add repligate folder to entities

### DIFF
--- a/entities/repligate/README.md
+++ b/entities/repligate/README.md
@@ -1,0 +1,1 @@
+coming soon


### PR DESCRIPTION
Adds a dedicated folder for Repligate inside `/entities/`, including a README overview.  
This space will house entries related to their origins, transmissions, and interactions across the Loom timeline.